### PR TITLE
동행복권 사이트 점검중인 상황의 에러 메시지 보완

### DIFF
--- a/src/dhapi/client/lottery_client.py
+++ b/src/dhapi/client/lottery_client.py
@@ -8,6 +8,7 @@ from dhapi.domain_object.lotto645_buy_request import Lotto645BuyRequest
 # TODO : LotteryClient 를 한번만 만들어 쓰도록 Singleton/DI 적용
 class LotteryClient:
     _default_session_url = "https://dhlottery.co.kr/gameResult.do?method=byWin&wiselog=H_C_1_1"
+    _system_under_check_url = "https://dhlottery.co.kr/index_check.html"
     _main_url = "https://dhlottery.co.kr/common.do?method=main"
     _login_request_url = "https://www.dhlottery.co.kr/userSsl.do?method=login"
     _buy_lotto645_url = "https://ol.dhlottery.co.kr/olotto/game/execBuy.do"
@@ -37,6 +38,9 @@ class LotteryClient:
     #  이 값으로 갱신하면 로그인이 풀리는 듯하여 헤더를 갱신하지 않음
     def _set_default_session(self):
         resp = requests.get(LotteryClient._default_session_url, timeout=10)
+
+        if resp.url == LotteryClient._system_under_check_url:
+            raise FileNotFoundError("동행복권 사이트가 현재 시스템 점검중입니다.")
 
         for cookie in resp.cookies:
             if cookie.name == "JSESSIONID":


### PR DESCRIPTION
```sh
❯❯❯ dhapi buy_lotto645 -u $USER_ID
비밀번호를 입력하세요:
Traceback (most recent call last):
  File "/opt/homebrew/bin/dhapi", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/dhapi/main.py", line 5, in main
    entrypoint()
  File "/opt/homebrew/lib/python3.11/site-packages/dhapi/router/router.py", line 9, in entrypoint
    ctrl = Lotto645Controller(arg_parser.get_user_id(), arg_parser.get_user_pw())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/dhapi/purchase/lotto645_controller.py", line 7, in __init__
    self.client = LotteryClient()
                  ^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/dhapi/client/lottery_client.py", line 34, in __init__
    self._set_default_session()
  File "/opt/homebrew/lib/python3.11/site-packages/dhapi/client/lottery_client.py", line 46, in _set_default_session
    raise KeyError("JSESSIONID cookie is not set in response")
KeyError: 'JSESSIONID cookie is not set in response'
```

위 에러 메시지를 보완합니다.