### PR TITLE
fix: JohnnyDist 라이브러리를 이용한 version check 로직 임시 비활성화

### DIFF
--- a/src/dhapi/router/version_checker.py
+++ b/src/dhapi/router/version_checker.py
@@ -17,8 +17,9 @@ def get_versions():
     """
     :return (installed_version, latest_version)
     """
-    dist = JohnnyDist(PACKAGE_NAME)
-    return dist.version_installed, dist.version_latest
+    # dist = JohnnyDist(PACKAGE_NAME)
+    # return dist.version_installed, dist.version_latest
+    return ("0.0.0", "0.0.0") # TODO(seonghyeok): Implement this function. JoynnyDist is not working.
 
 
 def suggest_upgrade():


### PR DESCRIPTION
- resolves https://github.com/roeniss/dhlottery-api/issues/50
- resolves https://github.com/roeniss/dhlottery-api/issues/49

사용하는 라이브러리가 최신 버전에서 모종의 이유로 정상 작동하지 않고 있음. 일단 비활성화 처리함