### PR TITLE
feat: 배포 자동화

### DIFF
--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -1,0 +1,50 @@
+name: Add verion tag and Publish to PyPI
+
+on:
+  push:
+    branches: [ "publish" ]
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      # set version
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: VERSION # only check out this file
+          sparse-checkout-cone-mode: false
+      - name: Get version
+        id: version
+        run: echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
+
+      # tag
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ steps.version.outputs.version }}
+
+  build-and-publish:
+    needs: tag
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      # build
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install Python Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      # build
+      - name: Execute publishing
+        run: make build
+
+      # publish
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
-publish: lintfmt clean
+build: clean
 	yes | pip3 install build twine
 	python3 -m build --sdist
 	python3 -m build --wheel
 	twine check dist/*
-	twine upload dist/*
 
-.PHONY : publish
+.PHONY : build
 
 
 clean:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,19 +33,11 @@ make lintfmt
 
 ### 배포
 
-pypi를 통해 배포합니다. ([pypi repository](https://pypi.org/project/dhapi/))
+이 작업은 메인테이너가 진행합니다.
 
-(build, setuptools, tween 필요)
-
-`setup.py`에서 'version'을 적절하게 bump 후 publish 합니다.
-
-그런데 pypi 저장소 토큰이 저한테 있어서... 지금은 저만 배포할 수 있습니다.
-
-```sh
-make publish
-```
-
-배포할 때마다, `setup.py` 와 `arg_parser.py` 의 버전 정보를 수동으로 갱신해주고 있습니다.
+1. main 브랜치에서 [VERSION](./VERSION) 을 수정한 후 publish 브랜치로 PR 생성합니다.
+2. CI가 통과되고 머지되면 배포를 위한 워크플로우가 진행됩니다. 이 과정에서 git tag가 생성됩니다.
+3. 생성된 tag로 GitHub Release를 생성합니다.
 
 ### 참고자료
 


### PR DESCRIPTION
- resolves https://github.com/roeniss/dhlottery-api/issues/38

1. Git Tagging, Dist building, Dist Publishing 을 하는 워크플로우 추가
2. CONTRIBUTING.md 문서에 배포 프로세스 기록
3. Makefile 의 `publish` 태스크 수정 (no build, rename to `build`)