### PR TITLE
fix: Remove lintfmt on main branch

### DIFF
--- a/.github/workflows/lintfmt.yml
+++ b/.github/workflows/lintfmt.yml
@@ -1,8 +1,6 @@
 name: Execute Lint Formatting
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
pull_request 로만 main 브랜치에 코드가 들어가도록 GitHub Rulesets 을 지정했기 때문에, 중복으로 CI 도는 일을 제거함