### PR TITLE
Fix credentials file creation prompt

### DIFF
--- a/tests/dhapi/port/test_credentials_provider.py
+++ b/tests/dhapi/port/test_credentials_provider.py
@@ -1,0 +1,31 @@
+import os
+import tomli
+import pytest
+from dhapi.port.credentials_provider import CredentialsProvider
+
+
+def test_create_credentials_file_when_missing(tmp_path, monkeypatch, mocker):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    inputs = iter(["y", "y", "user", "pass"])
+    mocker.patch("builtins.input", side_effect=lambda: next(inputs))
+
+    provider = CredentialsProvider("default")
+    user = provider.get_user()
+
+    assert user.username == "user"
+    assert user.password == "pass"
+
+    path = tmp_path / ".dhapi" / "credentials"
+    assert path.exists()
+    with open(path, "r", encoding="UTF-8") as f:
+        config = tomli.loads(f.read())
+    assert config["default"]["username"] == "user"
+    assert config["default"]["password"] == "pass"
+
+
+def test_error_when_user_declines_creation(tmp_path, monkeypatch, mocker):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    mocker.patch("builtins.input", return_value="n")
+
+    with pytest.raises(FileNotFoundError):
+        CredentialsProvider("default")


### PR DESCRIPTION
## Summary
- fix credentials provider to create `.dhapi/credentials` when missing
- test credentials provider interactive behaviours

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68806d48605883329b1ee9f85de695a6