### PR TITLE
Hide password input with getpass

### DIFF
--- a/src/dhapi/port/credentials_provider.py
+++ b/src/dhapi/port/credentials_provider.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import getpass
 
 import tomli
 import tomli_w
@@ -75,8 +76,7 @@ class CredentialsProvider:
         self._ensure_credentials_file()
         print("📝 사용자 ID를 입력하세요: ", end="")
         user_id = input().strip()
-        print("📝 사용자 비밀번호를 입력하세요: ", end="")
-        user_pw = input().strip()
+        user_pw = getpass.getpass("📝 사용자 비밀번호를 입력하세요: ")
 
         doc = {profile_name: {"username": user_id, "password": user_pw}}
 

--- a/tests/dhapi/port/test_credentials_provider.py
+++ b/tests/dhapi/port/test_credentials_provider.py
@@ -6,8 +6,9 @@ from dhapi.port.credentials_provider import CredentialsProvider
 
 def test_create_credentials_file_when_missing(tmp_path, monkeypatch, mocker):
     monkeypatch.setenv("HOME", str(tmp_path))
-    inputs = iter(["y", "y", "user", "pass"])
+    inputs = iter(["y", "y", "user"])
     mocker.patch("builtins.input", side_effect=lambda: next(inputs))
+    getpass_mock = mocker.patch("getpass.getpass", return_value="pass")
 
     provider = CredentialsProvider("default")
     user = provider.get_user()
@@ -21,6 +22,7 @@ def test_create_credentials_file_when_missing(tmp_path, monkeypatch, mocker):
         config = tomli.loads(f.read())
     assert config["default"]["username"] == "user"
     assert config["default"]["password"] == "pass"
+    assert getpass_mock.call_count == 1
 
 
 def test_error_when_user_declines_creation(tmp_path, monkeypatch, mocker):


### PR DESCRIPTION
## Summary
- use `getpass.getpass()` so passwords aren't echoed on the console
- adjust tests for the new password prompt

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=./src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880749e20fc833283ae0cf76ddbeb85