### PR TITLE
Enforce failing lintfmt when style issues detected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ clean:
 
 
 lintfmt:
-	black src/**
-	pylint src
+	black src --check --diff
+	pylint src --fail-under=10
 
 .PHONY : lintfmt
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -26,6 +26,8 @@ make lintfmt
 make test
 ```
 
+`make lintfmt` 명령은 `black`과 `pylint`를 검사 모드로 실행하여 형식이 맞지 않거나 pylint 점수가 10점 만점이 아닐 경우 종료 코드 1을 반환합니다.
+
 ### 배포
 
 이 작업은 메인테이너가 진행합니다.


### PR DESCRIPTION
## Summary
- ensure `make lintfmt` fails if formatting or lint score is not perfect
- document lint behavior in CONTRIBUTING guide

## Testing
- `make lintfmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6880769210148332b6bbc94445da7e6d