### PR TITLE
Update publish workflow trigger and docs

### DIFF
--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -1,7 +1,9 @@
 name: Add verion tag and Publish to PyPI
 
 on:
-  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+    tags: [ "v*" ]
 
 jobs:
   tag:
@@ -9,12 +11,11 @@ jobs:
     steps:
       # set version
       - uses: actions/checkout@v4
-        with:
-          sparse-checkout: VERSION # only check out this file
-          sparse-checkout-cone-mode: false
-      - name: Get version
+      - name: Get version from setuptools_scm
         id: version
-        run: echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
+        run: |
+          python -m pip install setuptools_scm
+          echo "version=$(python -c 'import setuptools_scm; print(setuptools_scm.get_version())')" >> $GITHUB_OUTPUT
 
       # tag
       - name: Bump version and push tag

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -31,9 +31,9 @@ make test
 
 이 작업은 메인테이너가 진행합니다.
 
-1. main 브랜치에서 [VERSION](./VERSION) 을 수정한 후 master 브랜치로 PR 생성합니다.
-2. CI가 통과되고 머지되면 [tag-and-publish 워크플로우](https://github.com/roeniss/dhlottery-api/actions/workflows/tag-and-publish.yml) 를 직접 수행합니다. 이렇게 하면 tag 생성이 진행되고 바로 이어서 Pypi 에 새 버전 배포가 진행됩니다.
-3. 생성된 tag로 GitHub Release 를 생성합니다.
+1. main 브랜치에서 새 버전을 `vX.Y.Z` 형식의 태그로 추가하고 push 합니다.
+2. 태그가 push 되면 [tag-and-publish 워크플로우](https://github.com/roeniss/dhlottery-api/actions/workflows/tag-and-publish.yml)가 자동으로 실행되어 PyPI 에 배포합니다.
+3. 배포가 완료되면 GitHub Release 를 작성합니다.
 
 ### 참고자료
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ typer==0.9.0
 rich==13.7.0
 pytest-mock==3.12.0
 click==8.1.8
+pyyaml==6.0.1

--- a/tests/test_workflow_trigger.py
+++ b/tests/test_workflow_trigger.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import yaml
+
+
+def test_tag_publish_workflow_trigger():
+    path = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "tag-and-publish.yml"
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    trigger = data.get("on") or data.get(True)
+    assert trigger is not None
+    assert "push" in trigger
+    push = trigger["push"]
+    assert "tags" in push
+    assert "v*" in push["tags"]
+
+


### PR DESCRIPTION
## Summary
- trigger publish workflow on push instead of manual dispatch
- compute tag from `setuptools_scm` in workflow
- document automated release process
- add regression test for workflow trigger
- require `pyyaml` for tests

## Testing
- `make lintfmt`
- `make check`
- `pip install -r requirements.txt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688085be5cbc8332beb8f42645b87617