### PR TITLE
Add version module and tag check

### DIFF
--- a/src/dhapi/__init__.py
+++ b/src/dhapi/__init__.py
@@ -1,0 +1,2 @@
+from ._version import __version__
+

--- a/src/dhapi/_version.py
+++ b/src/dhapi/_version.py
@@ -1,0 +1,14 @@
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+
+def _read_version_file() -> str:
+    version_path = Path(__file__).resolve().parents[1].parent / "VERSION"
+    return version_path.read_text(encoding="utf-8").strip()
+
+
+try:
+    __version__ = version("dhapi")
+except PackageNotFoundError:
+    __version__ = _read_version_file()
+

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,15 @@
+import subprocess
+
+from dhapi import __version__
+
+
+def test_version_matches_git_tag():
+    git_version = subprocess.check_output([
+        "git",
+        "describe",
+        "--tags",
+        "--abbrev=0",
+    ], text=True).strip()
+    expected = git_version.lstrip("v")
+    assert __version__ == expected
+


### PR DESCRIPTION
## Summary
- expose package version at `dhapi.__version__`
- implement fallback to `VERSION` file when the package isn't installed
- verify that `__version__` matches the latest git tag

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688085c00cdc833282f96103c68b224d