### PR TITLE
Fix: show_balance 메서드 JSON API로 변경

### DIFF
--- a/src/dhapi/endpoint/lottery_stdout_printer.py
+++ b/src/dhapi/endpoint/lottery_stdout_printer.py
@@ -17,18 +17,18 @@ class LotteryStdoutPrinter:
 
         console.print(table)
 
-    def print_result_of_show_balance(self, *, 총예치금, 구매가능금액, 예약구매금액, 출금신청중금액, 구매불가능금액, 이번달누적구매금액):
+    def print_result_of_show_balance(self, *, 총예치금, 구매가능금액, 예약구매금액, 출금신청중금액, 구매불가능금액, 최근1달누적구매금액):
         console = Console()
 
         console.print("✅ 예치금 현황을 조회했습니다.")
-        table = Table("총예치금", "구매가능금액", "예약구매금액", "출금신청중금액", "구매불가능금액", "이번달누적구매금액")
+        table = Table("총예치금", "구매가능금액", "예약구매금액", "출금신청중금액", "구매불가능금액", "최근1달누적구매금액")
         table.add_row(
             self._num_to_money_str(총예치금),
             self._num_to_money_str(구매가능금액),
             self._num_to_money_str(예약구매금액),
             self._num_to_money_str(출금신청중금액),
             self._num_to_money_str(구매불가능금액),
-            self._num_to_money_str(이번달누적구매금액),
+            self._num_to_money_str(최근1달누적구매금액),
         )
         console.print(table)
         console.print("[dim](구매불가능금액 = 예약구매금액 + 출금신청중금액)[/dim]")

--- a/src/dhapi/port/lottery_client.py
+++ b/src/dhapi/port/lottery_client.py
@@ -255,14 +255,11 @@ class LotteryClient:
             user_mndp = data.get("data", {}).get("userMndp", {})
 
             # 총예치금 계산 (웹사이트 JS 로직과 동일)
-            pnt_dpst_amt = user_mndp.get("pntDpstAmt", 0) or 0
-            pnt_tkmny_amt = user_mndp.get("pntTkmnyAmt", 0) or 0
-            ncsbl_dpst_amt = user_mndp.get("ncsblDpstAmt", 0) or 0
-            ncsbl_tkmny_amt = user_mndp.get("ncsblTkmnyAmt", 0) or 0
-            csbl_dpst_amt = user_mndp.get("csblDpstAmt", 0) or 0
-            csbl_tkmny_amt = user_mndp.get("csblTkmnyAmt", 0) or 0
-
-            총예치금 = (pnt_dpst_amt - pnt_tkmny_amt) + (ncsbl_dpst_amt - ncsbl_tkmny_amt) + (csbl_dpst_amt - csbl_tkmny_amt)
+            총예치금 = (
+                ((user_mndp.get("pntDpstAmt", 0) or 0) - (user_mndp.get("pntTkmnyAmt", 0) or 0))
+                + ((user_mndp.get("ncsblDpstAmt", 0) or 0) - (user_mndp.get("ncsblTkmnyAmt", 0) or 0))
+                + ((user_mndp.get("csblDpstAmt", 0) or 0) - (user_mndp.get("csblTkmnyAmt", 0) or 0))
+            )
             구매가능금액 = user_mndp.get("crntEntrsAmt", 0) or 0
             예약구매금액 = user_mndp.get("rsvtOrdrAmt", 0) or 0
             출금신청중금액 = user_mndp.get("dawAplyAmt", 0) or 0

--- a/src/dhapi/port/lottery_client.py
+++ b/src/dhapi/port/lottery_client.py
@@ -266,7 +266,7 @@ class LotteryClient:
             구매가능금액 = user_mndp.get("crntEntrsAmt", 0) or 0
             예약구매금액 = user_mndp.get("rsvtOrdrAmt", 0) or 0
             출금신청중금액 = user_mndp.get("dawAplyAmt", 0) or 0
-            구매불가능금액 = 예약구매금액 + 출금신청중금액
+            구매불가능금액 = 예약구매금액 + 출금신청중금액 + (user_mndp.get("feeAmt", 0) or 0)
 
             # 이번달 누적 구매금액 조회 (별도 API)
             이번달누적구매금액 = 0

--- a/src/dhapi/port/lottery_client.py
+++ b/src/dhapi/port/lottery_client.py
@@ -265,11 +265,11 @@ class LotteryClient:
             출금신청중금액 = user_mndp.get("dawAplyAmt", 0) or 0
             구매불가능금액 = 예약구매금액 + 출금신청중금액 + (user_mndp.get("feeAmt", 0) or 0)
 
-            # 이번달 누적 구매금액 조회 (별도 API)
-            이번달누적구매금액 = 0
+            # 최근 1달 누적 구매금액 조회
+            최근1달누적구매금액 = 0
             resp2 = self._session.get("https://www.dhlottery.co.kr/mypage/selectMyHomeInfo.do", headers=headers, timeout=10)
             if resp2.status_code == 200 and "json" in resp2.headers.get("Content-Type", "").lower():
-                이번달누적구매금액 = resp2.json().get("data", {}).get("mnthPrchsAmt", 0)
+                최근1달누적구매금액 = resp2.json().get("data", {}).get("mnthPrchsAmt", 0)
 
             self._lottery_endpoint.print_result_of_show_balance(
                 총예치금=총예치금,
@@ -277,7 +277,7 @@ class LotteryClient:
                 예약구매금액=예약구매금액,
                 출금신청중금액=출금신청중금액,
                 구매불가능금액=구매불가능금액,
-                이번달누적구매금액=이번달누적구매금액,
+                최근1달누적구매금액=최근1달누적구매금액,
             )
 
         except Exception:

--- a/src/dhapi/port/lottery_client.py
+++ b/src/dhapi/port/lottery_client.py
@@ -248,10 +248,18 @@ class LotteryClient:
             data = resp.json()
             user_mndp = data.get("data", {}).get("userMndp", {})
 
-            총예치금 = user_mndp.get("totalAmt", 0)
-            구매가능금액 = user_mndp.get("crntEntrsAmt", 0)
-            예약구매금액 = user_mndp.get("rsvtOrdrAmt", 0)
-            출금신청중금액 = user_mndp.get("dawAplyAmt", 0)
+            # 총예치금 계산 (웹사이트 JS 로직과 동일)
+            pnt_dpst_amt = user_mndp.get("pntDpstAmt", 0) or 0
+            pnt_tkmny_amt = user_mndp.get("pntTkmnyAmt", 0) or 0
+            ncsbl_dpst_amt = user_mndp.get("ncsblDpstAmt", 0) or 0
+            ncsbl_tkmny_amt = user_mndp.get("ncsblTkmnyAmt", 0) or 0
+            csbl_dpst_amt = user_mndp.get("csblDpstAmt", 0) or 0
+            csbl_tkmny_amt = user_mndp.get("csblTkmnyAmt", 0) or 0
+
+            총예치금 = (pnt_dpst_amt - pnt_tkmny_amt) + (ncsbl_dpst_amt - ncsbl_tkmny_amt) + (csbl_dpst_amt - csbl_tkmny_amt)
+            구매가능금액 = user_mndp.get("crntEntrsAmt", 0) or 0
+            예약구매금액 = user_mndp.get("rsvtOrdrAmt", 0) or 0
+            출금신청중금액 = user_mndp.get("dawAplyAmt", 0) or 0
             구매불가능금액 = 예약구매금액 + 출금신청중금액
 
             # 이번달 누적 구매금액 조회 (별도 API)

--- a/src/dhapi/port/lottery_client.py
+++ b/src/dhapi/port/lottery_client.py
@@ -240,8 +240,14 @@ class LotteryClient:
 
     def show_balance(self):
         try:
+            headers = {
+                "Accept": "application/json, text/javascript, */*; q=0.01",
+                "X-Requested-With": "XMLHttpRequest",
+                "Referer": self._cash_balance,
+            }
+
             # 예치금 정보 조회 (JSON API)
-            resp = self._session.get("https://www.dhlottery.co.kr/mypage/selectUserMndp.do", timeout=10)
+            resp = self._session.get("https://www.dhlottery.co.kr/mypage/selectUserMndp.do", headers=headers, timeout=10)
             if resp.status_code != 200 or "json" not in resp.headers.get("Content-Type", "").lower():
                 raise RuntimeError("예치금 API 응답 오류")
 
@@ -264,7 +270,7 @@ class LotteryClient:
 
             # 이번달 누적 구매금액 조회 (별도 API)
             이번달누적구매금액 = 0
-            resp2 = self._session.get("https://www.dhlottery.co.kr/mypage/selectMyHomeInfo.do", timeout=10)
+            resp2 = self._session.get("https://www.dhlottery.co.kr/mypage/selectMyHomeInfo.do", headers=headers, timeout=10)
             if resp2.status_code == 200 and "json" in resp2.headers.get("Content-Type", "").lower():
                 이번달누적구매금액 = resp2.json().get("data", {}).get("mnthPrchsAmt", 0)
 

--- a/src/dhapi/router/router.py
+++ b/src/dhapi/router/router.py
@@ -53,11 +53,9 @@ def assign_virtual_account(
     client.assign_virtual_account(deposit)
 
 
-@app.command(
-    help="""
+@app.command(help="""
 예치금 현황을 조회합니다.
-"""
-)
+""")
 def show_balance(
     profile: Annotated[str, typer.Option("-p", "--profile", help="프로필을 지정합니다", metavar="")] = "default",
     _debug: Annotated[bool, typer.Option("-d", "--debug", help="debug 로그를 활성화합니다.", callback=logger_callback)] = False,
@@ -68,13 +66,11 @@ def show_balance(
     client.show_balance()
 
 
-@app.command(
-    help="""
+@app.command(help="""
 구매 내역을 조회합니다.
 
 기본적으로 최근 14일간의 내역을 조회하며, --start-date 및 --end-date 옵션을 통해 조회 기간을 지정할 수 있습니다.
-"""
-)
+""")
 def show_buy_list(
     profile: Annotated[str, typer.Option("-p", "--profile", help="프로필을 지정합니다", metavar="")] = "default",
     output_format: Annotated[str, typer.Option("-f", "--format", help="출력 형식을 지정합니다 (table, json).")] = "table",
@@ -105,8 +101,7 @@ def show_profiles():
     console.print(table)
 
 
-@app.command(
-    help="""
+@app.command(help="""
 로또6/45 복권을 구매합니다.
 
 매주 최대 다섯 장까지 구매할 수 있습니다 (5 tickets).
@@ -124,8 +119,7 @@ dhapi buy-lotto645 '1,2,3' : 반자동모드 1장 (고정번호: 1,2,3)
 dhapi buy-lotto645 '1,2,3,4,5,6' '7,8,9' : 수동모드 1장 (고정번호: 1,2,3,4,5,6), 반자동모드 1장 (고정번호: 7,8,9)
 
 dhapi buy-lotto645 '' '' '' '1' : 자동모드 3장, 반자동모드 1장 (고정번호: 1)
-"""
-)
+""")
 def buy_lotto645(
     tickets: Annotated[List[str], typer.Argument(help="구매할 번호를 입력합니다. 생략 시 자동모드로 5장 구매합니다.", metavar="tickets", show_default=False)] = None,
     always_yes: Annotated[bool, typer.Option("-y", "--yes", help="구매 전 확인 절차를 스킵합니다.")] = False,
@@ -146,11 +140,9 @@ def buy_lotto645(
     client.buy_lotto645(tickets)
 
 
-@app.command(
-    help="""
+@app.command(help="""
 dhapi 버전을 출력합니다.
-"""
-)
+""")
 def version():
     version_callback(True)
 


### PR DESCRIPTION
동행복권 사이트 리뉴얼로 인해 마이페이지 HTML 구조가 변경되어,
show-balance에서 기존 CSS 셀렉터 기반 파싱이 실패하는 문제를 수정했습니다. 

- 기존: BeautifulSoup HTML 파싱 (CSS 셀렉터)
- 변경: JSON API 호출
  - /mypage/selectUserMndp.do
  - /mypage/selectMyHomeInfo.do
  
추가: API에서는 "이번달 누적구매금액" 대신 "최근 30일 누적구매금액"이 제공되는 것으로 보입니다 (제 구매 기록과 비교 확인). 기존 동작과 차이가 발생할 수 있으니 검토 부탁드립니다.