### PR TITLE
Chore: 릴리즈 워크플로에 main 한정 + 태그/PyPI 가드 추가

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -10,37 +10,48 @@ jobs:
       id-token: write
 
     steps:
-      - name: Enforce dispatch from main only
-        run: |
-          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
-            echo "::error::This workflow must be dispatched from 'main', got '${GITHUB_REF}'."
-            exit 1
-          fi
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # to get tags
 
-      - name: Resolve tag at main HEAD
+      - name: Pre-flight checks
         id: tag
         run: |
+          fail() {
+            {
+              echo "## Release pre-flight FAILED"
+              echo ""
+              echo "**Reason:** $1"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::$1"
+            exit 1
+          }
+
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            fail "Workflow must be dispatched from 'main' (got '${GITHUB_REF}')."
+          fi
+
           TAG=$(git tag --points-at HEAD | grep '^v' | sort -V | tail -n1)
           if [ -z "$TAG" ]; then
-            echo "::error::main HEAD ($(git rev-parse --short HEAD)) has no version tag (vX.Y.Z). Tag the release commit before dispatching."
-            exit 1
+            fail "main HEAD ($(git rev-parse --short HEAD)) has no version tag (vX.Y.Z)."
           fi
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Verify version is not already on PyPI
-        run: |
-          VERSION="${{ steps.tag.outputs.version }}"
+          VERSION="${TAG#v}"
           STATUS=$(curl -sS -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/dhapi/${VERSION}/json")
           case "$STATUS" in
-            404) echo "dhapi==${VERSION} is not on PyPI yet, proceeding." ;;
-            200) echo "::error::dhapi==${VERSION} is already published on PyPI"; exit 1 ;;
-            *)   echo "::error::Unexpected PyPI response: HTTP ${STATUS}"; exit 1 ;;
+            404) ;;
+            200) fail "dhapi==${VERSION} is already published on PyPI." ;;
+            *)   fail "Unexpected PyPI response: HTTP ${STATUS} when querying dhapi==${VERSION}." ;;
           esac
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Release pre-flight OK"
+            echo ""
+            echo "- tag: \`$TAG\`"
+            echo "- version: \`$VERSION\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -10,9 +10,38 @@ jobs:
       id-token: write
 
     steps:
+      - name: Enforce dispatch from main only
+        run: |
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "::error::This workflow must be dispatched from 'main', got '${GITHUB_REF}'."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # to get tags
+
+      - name: Resolve tag at main HEAD
+        id: tag
+        run: |
+          TAG=$(git tag --points-at HEAD | grep '^v' | sort -V | tail -n1)
+          if [ -z "$TAG" ]; then
+            echo "::error::main HEAD ($(git rev-parse --short HEAD)) has no version tag (vX.Y.Z). Tag the release commit before dispatching."
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify version is not already on PyPI
+        run: |
+          VERSION="${{ steps.tag.outputs.version }}"
+          STATUS=$(curl -sS -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/dhapi/${VERSION}/json")
+          case "$STATUS" in
+            404) echo "dhapi==${VERSION} is not on PyPI yet, proceeding." ;;
+            200) echo "::error::dhapi==${VERSION} is already published on PyPI"; exit 1 ;;
+            *)   echo "::error::Unexpected PyPI response: HTTP ${STATUS}"; exit 1 ;;
+          esac
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'


### PR DESCRIPTION
## 변경

수동 dispatch 자체는 유지(릴리즈는 사람이 명시적으로 트리거). 다만 사고 방지를 위해 잡 시작부에 다음 가드 3개를 추가:

1. **main 한정** — `GITHUB_REF != refs/heads/main` 이면 즉시 실패. dispatch 시 다른 브랜치를 선택해도 publish 막힘
2. **태그 존재** — `git tag --points-at HEAD` 로 `v*` 태그 조회. 없으면 실패. setuptools-scm dev 버전이 PyPI 로 새는 사고 방지
3. **PyPI 중복 방지** — `https://pypi.org/pypi/dhapi/<version>/json` 으로 사전 조회. 200(이미 존재) 이면 실패, 404 면 진행

## 의도된 운영 흐름

1. main 에 릴리즈 커밋 머지
2. `git tag vX.Y.Z <sha> && git push origin vX.Y.Z`
3. Actions 탭 → Run workflow (입력 없음)
4. 가드 통과하면 PyPI 업로드

## Test plan

- [x] main 이 아닌 브랜치에서 dispatch → "must be dispatched from 'main'" 으로 실패하는지
- [x] HEAD 에 태그 없는 main 에서 dispatch → "no version tag" 로 실패하는지
- [x] 이미 publish 된 버전 태그로 dispatch → "already published on PyPI" 로 실패하는지
- [x] 신규 태그(`vX.Y.(Z+1)`) 푸시 후 dispatch → 정상 빌드/배포되는지